### PR TITLE
Add pt_BR translation and fix typo "turnstill" → "turnstile"

### DIFF
--- a/app/locale/en_US/Fballiano_Turnstile.csv
+++ b/app/locale/en_US/Fballiano_Turnstile.csv
@@ -1,4 +1,4 @@
 "CSS Selectors","CSS Selectors"
 "Enable","Enable"
 "Incorrect CAPTCHA.","Incorrect CAPTCHA."
-"These CSS selectors are used to identify the forms for which Turnstile will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","These CSS selectors are used to identify the forms for which Turnstill will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line."
+"These CSS selectors are used to identify the forms for which Turnstile will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","These CSS selectors are used to identify the forms for which Turnstile will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line."

--- a/app/locale/it_IT/Fballiano_Turnstile.csv
+++ b/app/locale/it_IT/Fballiano_Turnstile.csv
@@ -1,4 +1,4 @@
 "CSS Selectors","Selettori CSS"
 "Enable","Abilita"
 "Incorrect CAPTCHA.","CAPTCHA non corretto."
-"These CSS selectors are used to identify the forms for which Turnstill will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","Questi selettori CSS identificano i form su cui sarà attivato Turnstile.<br />Un selettore per riga.<br />Per disabilitare un selettore digitare // all'inizio della riga."
+"These CSS selectors are used to identify the forms for which Turnstile will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","Questi selettori CSS identificano i form su cui sarà attivato Turnstile.<br />Un selettore per riga.<br />Per disabilitare un selettore digitare // all'inizio della riga."

--- a/app/locale/pt_BR/Fballiano_Turnstile.csv
+++ b/app/locale/pt_BR/Fballiano_Turnstile.csv
@@ -1,0 +1,4 @@
+"CSS Selectors","Seletores CSS"
+"Enable","Habilitar"
+"Incorrect CAPTCHA.","CAPTCHA incorreto."
+"These CSS selectors are used to identify the forms for which Turnstile will be activated.<br />One selector per line.<br />To disable a selector, type // at the beginning of the line.","Esses seletores CSS identificam os formulários nos quais o Turnstile será ativado.<br />Um seletor por linha.<br />Para desabilitar um seletor, digite // no início da linha."


### PR DESCRIPTION
This commit introduces a new Brazilian Portuguese (pt_BR) translation for the extension and fixes a typo where "turnstill" was incorrectly used. It has been corrected to "turnstile" to ensure consistency across the codebase and translations.
